### PR TITLE
Add MongoDB import for the content tree

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy to .env and adjust. .env is gitignored.
+MONGO_USER=root
+MONGO_PASSWORD=devpassword
+MONGO_URI=mongodb://root:devpassword@localhost:27017/compendium?authSource=admin

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .idea
 .claude/
 local/
+.env
+__pycache__/
+*.pyc

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,25 @@
+# Local development only. Production uses a managed MongoDB instance -- see
+# scripts/mongo/README.md. The Ktor `api` service joins this file later.
+services:
+  mongo:
+    image: mongo:8
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER:-root}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD:-devpassword}
+      MONGO_INITDB_DATABASE: compendium
+    ports:
+      # Bound to loopback so the database is reachable from Compass on this
+      # machine but not from the local network.
+      - "127.0.0.1:27017:27017"
+    volumes:
+      - mongo-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')", "--quiet"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+
+volumes:
+  mongo-data:

--- a/json/pt-br/sources/psb3/monsters.json
+++ b/json/pt-br/sources/psb3/monsters.json
@@ -1004,7 +1004,7 @@
         ],
         "source": {
             "name": "Fichas do Jogador 3",
-            "acronym": "BEJ3"
+            "acronym": "PSB3"
         }
     }
 ]

--- a/scripts/mongo/README.md
+++ b/scripts/mongo/README.md
@@ -1,0 +1,116 @@
+# MongoDB import
+
+Loads the JSON content tree into MongoDB so a backend API and a web editor can
+work against it. The app keeps consuming the JSON files, so **the files remain
+the delivery mechanism** — the database is the editing source of truth, and
+`export.py` regenerates the tree.
+
+Everything here is built around one property: **the round trip is byte-exact.**
+`export.py` reproduces all 57 files exactly as they are on disk. Without that,
+publishing an edit would also reformat unrelated content.
+
+## Setup
+
+```bash
+python3 -m pip install --user pymongo
+cp .env.example .env
+docker compose up -d mongo
+python3 scripts/mongo/import.py
+```
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `python3 scripts/mongo/verify.py` | Round trip + validator fit + integrity report. **No database needed.** |
+| `python3 scripts/mongo/import.py` | Load everything. Idempotent. |
+| `python3 scripts/mongo/import.py --dry-run` | Read and check, write nothing. No database needed. |
+| `python3 scripts/mongo/import.py --drop` | Rebuild from scratch. |
+| `python3 scripts/mongo/import.py --strict` | Also exit non-zero on content integrity errors. |
+| `python3 scripts/mongo/export.py --check` | Confirm the database still reproduces `json/` exactly. |
+| `python3 scripts/mongo/export.py --in-place` | Write the database back over `json/` — the future `/publish`. |
+
+## Collections
+
+| Collection | Docs | `_id` |
+|---|---|---|
+| `monsters` | 4,207 | `<locale>:<source_acronym>:<index>` |
+| `spells` | 2,196 | `<locale>:<source_acronym>:<index>` |
+| `conditions` | 45 | `<locale>:<index>` |
+| `sources` | 41 | `<locale>:<catalog>:<acronym>` |
+| `_file_meta` | 57 | repo-relative path |
+
+`index` alone is **not** unique: 113 monster indexes appear in more than one
+source (`bugbear-chief` is in `MM`, `MM-LEGACY` and `SRD2024`). The composite
+key is the reason the import can be idempotent.
+
+`_file_meta` records per-file indent width and trailing newline. The tree is not
+formatted consistently — the 2024-era sources use `indent=2`, everything older
+uses `indent=4` — so this is measured on import rather than assumed. **Export
+cannot reproduce the files without it.**
+
+### Derived fields
+
+Added by the import, stripped on export:
+
+- `locale`, `source_acronym` — flattened from the file's position in the tree.
+- `lineage` / `edition` / `role` — `MM`, `MM2024` and `MM-LEGACY` are three
+  sources in one family. The `*-LEGACY` sources are *deltas*: `MM-LEGACY` holds
+  exactly the 7 entries dropped from the 2024 edition, not a 2014 catalog.
+  `role` is `full` or `legacy-remainder`.
+- `translated_from_rev` — hash of the `en-us` entry a translation was made
+  from. Missing translations are a set difference; *stale* ones are invisible
+  without this, and that is what ships wrong content.
+
+The virtual `SRD` source covers `json/<locale>/monsters.json` and
+`spells.json`, which have no source directory but are referenced as `SRD` by
+the configs.
+
+## What is deliberately not normalised
+
+The corpus is inconsistent in two ways that are **preserved, not fixed**:
+
+- `desc` vs `description` — `special_abilities` uses `desc` 1,677 times and
+  `description` 550 times; `reactions` 67 vs 57. The app falls back between
+  them. Normalising requires checking the app's parser first.
+- `damage_dices` vs `damage_dices_v2` — 31 actions carry both, a half-finished
+  migration.
+
+The validators accept either. Verified: all 4,207 monsters pass.
+
+## Source configs
+
+Imported from `content-sources.json` (catalog `full`) and
+`content-sources-basic.json` (catalog `basic`). The older
+`default-sources.json` / `alternative-sources.json` /
+`alternative-sources-basic.json` trio is **superseded** and not imported —
+`content-sources.json` is their union plus the 2024 entries. Note `CLAUDE.md`
+still documents the old pair.
+
+`totalMonsters` / `totalSpells` are imported as `declared_total_monsters` /
+`declared_total_spells`, so nothing in the database looks authoritative when it
+is not. The real count is an aggregation over `monsters`; `import.py` reports
+where the two disagree.
+
+## Integrity report
+
+Every run ends with findings about the content tree. These are **pre-existing
+conditions, not import failures** — nothing is repaired automatically. Current
+baseline: 1 error, 9 warnings.
+
+The error is `json/pt-br/sources/psb3/monsters.json` carrying `source.acronym:
+"BEJ3"` on one entry — a translation leaked into an identifier field.
+
+`import.py` exits non-zero only when the **import** fails (duplicate keys inside
+a file, a validator that could not be applied). Integrity findings describe the
+content tree, not the run, so they do not fail it — otherwise every run would
+report failure until unrelated content is edited. Pass `--strict` in a pipeline
+that should block on them.
+
+## Not yet imported
+
+Lore (~6,000 entries; lore sources are a separate taxonomy of 38 adventure
+books, and lore covers 703 monster indexes with no stat block), images
+(`json/monster-images.json`, 1,023 entries, locale-independent), and the legacy
+root files `json/monsters.json` / `json/spells.json` (last touched 2023 and
+2022, strict subsets of the locale files).

--- a/scripts/mongo/db.py
+++ b/scripts/mongo/db.py
@@ -1,0 +1,108 @@
+"""MongoDB connection and collection setup."""
+
+import os
+import sys
+
+DEFAULT_URI = "mongodb://root:devpassword@localhost:27017/compendium?authSource=admin"
+DEFAULT_DB = "compendium"
+
+
+def _load_dotenv():
+    path = os.path.join(os.path.dirname(__file__), "..", "..", ".env")
+    path = os.path.abspath(path)
+    if not os.path.exists(path):
+        return
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def connect(uri=None, timeout_ms=5000):
+    """Return a Database handle, or exit with a useful message if unreachable."""
+    try:
+        from pymongo import MongoClient
+        from pymongo.errors import PyMongoError
+    except ImportError:
+        sys.exit("pymongo is not installed. Run: python3 -m pip install --user pymongo")
+
+    _load_dotenv()
+    uri = uri or os.environ.get("MONGO_URI") or DEFAULT_URI
+    client = MongoClient(uri, serverSelectionTimeoutMS=timeout_ms)
+    try:
+        client.admin.command("ping")
+    except PyMongoError as exc:
+        sys.exit(
+            "Could not reach MongoDB at %s\n  %s\n\n"
+            "Start the local instance with:  docker compose up -d mongo\n"
+            "or point MONGO_URI at another server."
+            % (uri.split("@")[-1], exc)
+        )
+    name = client.get_default_database().name if "/" in uri.split("//")[-1] else DEFAULT_DB
+    return client[name or DEFAULT_DB]
+
+
+def ensure_indexes(database, index_specs, text_specs):
+    """Create indexes if absent. Safe to re-run."""
+    created = []
+    for collection_name, specs in index_specs.items():
+        collection = database[collection_name]
+        for keys, options in specs:
+            name = options.get("name")
+            existing = collection.index_information()
+            if name in existing:
+                continue
+            collection.create_index([(k, 1) for k in keys], **options)
+            created.append("%s.%s" % (collection_name, name))
+    for collection_name, (field, name) in text_specs.items():
+        collection = database[collection_name]
+        if name not in collection.index_information():
+            collection.create_index([(field, "text")], name=name)
+            created.append("%s.%s" % (collection_name, name))
+    return created
+
+
+def apply_validators(database, validators):
+    """Attach $jsonSchema validators after loading.
+
+    Applied after the data is in so that a pre-existing violation surfaces as a
+    report line rather than aborting the import half way through. validationLevel
+    "moderate" leaves existing documents alone and checks inserts and updates.
+    """
+    from pymongo.errors import PyMongoError
+
+    applied, failed = [], []
+    existing = set(database.list_collection_names())
+    for name, schema in validators.items():
+        if name not in existing:
+            database.create_collection(name)
+        try:
+            database.command({
+                "collMod": name,
+                "validator": {"$jsonSchema": schema},
+                "validationLevel": "moderate",
+                "validationAction": "error",
+            })
+            applied.append(name)
+        except PyMongoError as exc:
+            failed.append((name, str(exc)))
+    return applied, failed
+
+
+def bulk_upsert(database, collection_name, documents, batch_size=500):
+    """Idempotent load: re-running converges instead of duplicating."""
+    from pymongo import ReplaceOne
+
+    collection = database[collection_name]
+    inserted = modified = matched = 0
+    for start in range(0, len(documents), batch_size):
+        batch = documents[start:start + batch_size]
+        operations = [ReplaceOne({"_id": d["_id"]}, d, upsert=True) for d in batch]
+        result = collection.bulk_write(operations, ordered=False)
+        inserted += len(result.upserted_ids or {})
+        modified += result.modified_count
+        matched += result.matched_count
+    return {"inserted": inserted, "modified": modified, "matched": matched}

--- a/scripts/mongo/export.py
+++ b/scripts/mongo/export.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Rebuild the JSON content tree from MongoDB.
+
+This is the inverse of import.py and the code path a future /publish endpoint
+should reuse: the app keeps consuming the files, so the database is only the
+editing source of truth until this runs.
+
+    python3 scripts/mongo/export.py --check           # diff against json/, write nothing
+    python3 scripts/mongo/export.py --out /tmp/out
+    python3 scripts/mongo/export.py --in-place        # overwrite json/
+"""
+
+import argparse
+import difflib
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from mongo import db as dbmod        # noqa: E402
+from mongo import manifest as mf     # noqa: E402
+from mongo import transform          # noqa: E402
+
+COLLECTIONS = ["monsters", "spells", "conditions", "sources"]
+
+
+def load_from_db(database):
+    collections_map = {}
+    for name in COLLECTIONS:
+        collections_map[name] = list(database[name].find({}))
+    file_meta = list(database[mf.FILE_META_COLLECTION].find({}))
+    if not file_meta:
+        sys.exit(
+            "No %s documents found. Run import.py first -- per-file formatting "
+            "(indent width, trailing newline) is recorded there and the files "
+            "cannot be reproduced byte-for-byte without it."
+            % mf.FILE_META_COLLECTION
+        )
+    return collections_map, file_meta
+
+
+def write_tree(rebuilt, out_root):
+    for relpath, text in sorted(rebuilt.items()):
+        target = os.path.join(out_root, relpath)
+        directory = os.path.dirname(target)
+        if not os.path.isdir(directory):
+            os.makedirs(directory)
+        with open(target, "w", encoding="utf-8") as handle:
+            handle.write(text)
+
+
+def check(rebuilt, show_diff=False):
+    """Compare against the working tree. Returns the list of differing paths."""
+    differing = []
+    for relpath, text in sorted(rebuilt.items()):
+        original_path = os.path.join(mf.REPO_ROOT, relpath)
+        if not os.path.exists(original_path):
+            differing.append(relpath)
+            continue
+        with open(original_path, encoding="utf-8") as handle:
+            original = handle.read()
+        if text != original:
+            differing.append(relpath)
+            if show_diff:
+                diff = difflib.unified_diff(
+                    original.splitlines(True), text.splitlines(True),
+                    fromfile=relpath + " (working tree)",
+                    tofile=relpath + " (from database)", n=1,
+                )
+                sys.stdout.writelines(list(diff)[:40])
+    return differing
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--check", action="store_true",
+                       help="compare with the working tree, write nothing")
+    group.add_argument("--out", help="write the rebuilt tree under this directory")
+    group.add_argument("--in-place", action="store_true",
+                       help="overwrite the files in json/")
+    parser.add_argument("--diff", action="store_true", help="show diffs with --check")
+    parser.add_argument("--uri", help="MongoDB URI (default: $MONGO_URI)")
+    args = parser.parse_args(argv)
+
+    database = dbmod.connect(args.uri)
+    collections_map, file_meta = load_from_db(database)
+    counts = ", ".join("%s %d" % (k, len(v)) for k, v in collections_map.items())
+    print("Read from %r: %s" % (database.name, counts))
+
+    rebuilt = transform.documents_to_files(collections_map, file_meta)
+    print("Rebuilt %d files" % len(rebuilt))
+
+    if args.check:
+        differing = check(rebuilt, args.diff)
+        if differing:
+            print("\n%d file(s) differ from the working tree:" % len(differing))
+            for relpath in differing:
+                print("  %s" % relpath)
+            return 1
+        print("\nAll %d files are byte-identical to the working tree." % len(rebuilt))
+        return 0
+
+    out_root = mf.REPO_ROOT if args.in_place else args.out
+    write_tree(rebuilt, out_root)
+    print("Wrote %d files under %s" % (len(rebuilt), out_root))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mongo/import.py
+++ b/scripts/mongo/import.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Load the JSON content tree into MongoDB.
+
+Idempotent: re-running converges on the same state rather than duplicating.
+
+    python3 scripts/mongo/import.py                 # load everything
+    python3 scripts/mongo/import.py --dry-run       # no database needed
+    python3 scripts/mongo/import.py --collection monsters
+    python3 scripts/mongo/import.py --drop          # rebuild from scratch
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from mongo import db as dbmod          # noqa: E402
+from mongo import manifest as mf       # noqa: E402
+from mongo import report as reportmod  # noqa: E402
+from mongo import schemas              # noqa: E402
+from mongo import transform            # noqa: E402
+
+COLLECTIONS = ["monsters", "spells", "conditions", "sources"]
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--collection", action="append", choices=COLLECTIONS,
+                        help="limit to one collection (repeatable)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="read and validate, write nothing; needs no database")
+    parser.add_argument("--drop", action="store_true",
+                        help="drop the target collections before loading")
+    parser.add_argument("--uri", help="MongoDB URI (default: $MONGO_URI)")
+    parser.add_argument("--quiet", action="store_true", help="suppress the integrity report")
+    parser.add_argument("--strict", action="store_true",
+                        help="also fail when the content tree has integrity errors "
+                             "(by default those are reported but do not fail the run)")
+    return parser.parse_args(argv)
+
+
+def _exit_code(args, duplicates, failed_validators, findings):
+    """Non-zero means the import itself did not succeed.
+
+    Integrity findings describe the content tree, not the run: they are
+    pre-existing conditions that nothing here repairs, so failing on them would
+    mean the import reports failure on every run until unrelated content is
+    edited. Use --strict in a pipeline that should block on them.
+    """
+    if duplicates or failed_validators:
+        return 1
+    if args.strict and reportmod.error_count(findings):
+        print("Failing because --strict was given and the content tree has "
+              "%d integrity error(s)." % reportmod.error_count(findings))
+        return 1
+    return 0
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    targets = args.collection or COLLECTIONS
+
+    print("Reading content tree from %s" % mf.JSON_ROOT)
+    collections_map, file_meta, duplicates = transform.files_to_documents()
+    for path, index in duplicates:
+        print("  ERROR duplicate index %r inside %s" % (index, path))
+
+    for name in COLLECTIONS:
+        marker = " " if name in targets else "-"
+        print("  %s %-11s %5d documents" % (marker, name, len(collections_map[name])))
+    print("  %s %-11s %5d files" % (" ", "file meta", len(file_meta)))
+
+    findings = reportmod.run(collections_map, file_meta)
+
+    if args.dry_run:
+        print("\nDry run: nothing written.")
+        if not args.quiet:
+            print(reportmod.render(findings))
+        return _exit_code(args, duplicates, [], findings)
+
+    database = dbmod.connect(args.uri)
+    print("\nConnected to database %r" % database.name)
+
+    if args.drop:
+        for name in targets + [mf.FILE_META_COLLECTION]:
+            database[name].drop()
+        print("Dropped: %s" % ", ".join(targets + [mf.FILE_META_COLLECTION]))
+
+    for name in targets:
+        stats = dbmod.bulk_upsert(database, name, collections_map[name])
+        print("  %-11s inserted %-5d replaced %-5d (matched %d)"
+              % (name, stats["inserted"], stats["modified"], stats["matched"]))
+
+    meta_stats = dbmod.bulk_upsert(database, mf.FILE_META_COLLECTION, file_meta)
+    print("  %-11s inserted %-5d replaced %-5d"
+          % (mf.FILE_META_COLLECTION, meta_stats["inserted"], meta_stats["modified"]))
+
+    created = dbmod.ensure_indexes(
+        database,
+        {k: v for k, v in schemas.INDEXES.items() if k in targets},
+        {k: v for k, v in schemas.TEXT_INDEXES.items() if k in targets},
+    )
+    print("\nIndexes created: %s" % (", ".join(created) if created else "none (already present)"))
+
+    applied, failed = dbmod.apply_validators(
+        database, {k: v for k, v in schemas.VALIDATORS.items() if k in targets})
+    print("Validators applied: %s" % ", ".join(applied))
+    for name, error in failed:
+        print("  ERROR could not apply validator to %s: %s" % (name, error))
+
+    for name in targets:
+        print("  %-11s %5d documents in database" % (name, database[name].count_documents({})))
+
+    if not args.quiet:
+        print(reportmod.render(findings))
+
+    return _exit_code(args, duplicates, failed, findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mongo/manifest.py
+++ b/scripts/mongo/manifest.py
@@ -1,0 +1,133 @@
+"""Static description of the content tree: locales, sources, and where files live.
+
+Adding a locale or a source book should be a change to the tables here and
+nothing else.
+"""
+
+import os
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+JSON_ROOT = os.path.join(REPO_ROOT, "json")
+
+LOCALES = ["en-us", "pt-br", "es"]
+BASE_LOCALE = "en-us"
+
+# Directory name under json/<locale>/sources/ -> the acronym expected inside the
+# files it contains. Directories are lowercase, acronyms are uppercase.
+DIR_TO_ACRONYM = {
+    "erlw": "ERLW",
+    "ggr": "GGR",
+    "mm": "MM",
+    "mm-legacy": "MM-LEGACY",
+    "mm2024": "MM2024",
+    "mtf": "MTF",
+    "phb2024": "PHB2024",
+    "psb3": "PSB3",
+    "srd-legacy": "SRD-LEGACY",
+    "srd2024": "SRD2024",
+    "vgm": "VGM",
+    "vrgr": "VRGR",
+}
+
+# The locale-root monsters.json / spells.json have no source directory. Every
+# config file refers to that content as the "SRD" source, so it is imported
+# under a virtual acronym.
+VIRTUAL_SOURCE = "SRD"
+
+# Edition lineage. The *-LEGACY sources are deltas -- they hold exactly the
+# entries dropped from the 2024 edition, not a full 2014 catalog -- so acronym
+# alone does not tell you how two sources relate.
+#   lineage: the book family
+#   edition: which ruleset the stat blocks are written for
+#   role:    "full" = a complete catalog, "legacy-remainder" = dropped entries
+LINEAGE = {
+    "SRD":         ("SRD", 2014, "full"),
+    "SRD2024":     ("SRD", 2024, "full"),
+    "SRD-LEGACY":  ("SRD", 2014, "legacy-remainder"),
+    "MM":          ("MM", 2014, "full"),
+    "MM2024":      ("MM", 2024, "full"),
+    "MM-LEGACY":   ("MM", 2014, "legacy-remainder"),
+    "PHB2024":     ("PHB", 2024, "full"),
+    "MTF":         ("MTF", 2014, "full"),
+    "GGR":         ("GGR", 2014, "full"),
+    "VGM":         ("VGM", 2014, "full"),
+    "VRGR":        ("VRGR", 2014, "full"),
+    "ERLW":        ("ERLW", 2014, "full"),
+    "PSB3":        ("PSB3", 2014, "full"),
+}
+
+# Source-config files. The alternative-sources*/default-sources trio they
+# replaced is deliberately not imported -- content-sources.json is their union
+# plus the 2024 entries, and the older files have not been touched since the
+# 2024 content landed.
+SOURCE_CONFIGS = [
+    ("full", "content-sources.json"),
+    ("basic", "content-sources-basic.json"),
+]
+
+# Keys this pipeline adds to every document. Stripped again on export, so the
+# original key order of the untouched keys survives a round trip.
+INJECTED_KEYS = [
+    "_id",
+    "locale",
+    "source_acronym",
+    "catalog",
+    "acronym",
+    "lineage",
+    "edition",
+    "role",
+    "translated_from_rev",
+]
+
+# Reversible renames applied to source-config documents, so that a field named
+# totalMonsters in the database can never be mistaken for the authoritative
+# count (the real one is an aggregation over the monsters collection).
+SOURCE_FIELD_RENAMES = {
+    "totalMonsters": "declared_total_monsters",
+    "totalSpells": "declared_total_spells",
+}
+
+FILE_META_COLLECTION = "_file_meta"
+
+
+def rel(path):
+    """Repo-relative path, used as the stable id for per-file metadata."""
+    return os.path.relpath(path, REPO_ROOT)
+
+
+def locale_dir(locale):
+    return os.path.join(JSON_ROOT, locale)
+
+
+def source_dir(locale, dirname):
+    return os.path.join(JSON_ROOT, locale, "sources", dirname)
+
+
+def lineage_for(acronym):
+    return LINEAGE.get(acronym, (acronym, None, "full"))
+
+
+def content_files(locale, kind):
+    """Yield (acronym, absolute path) for a locale and kind ("monsters"/"spells").
+
+    Missing files are skipped -- phb2024 is spells-only, and not every source
+    dir exists in every locale.
+    """
+    root_file = os.path.join(locale_dir(locale), kind + ".json")
+    if os.path.exists(root_file):
+        yield VIRTUAL_SOURCE, root_file
+    for dirname in sorted(DIR_TO_ACRONYM):
+        path = os.path.join(source_dir(locale, dirname), kind + ".json")
+        if os.path.exists(path):
+            yield DIR_TO_ACRONYM[dirname], path
+
+
+def conditions_file(locale):
+    return os.path.join(locale_dir(locale), "conditions.json")
+
+
+def source_config_files(locale):
+    for catalog, filename in SOURCE_CONFIGS:
+        path = os.path.join(locale_dir(locale), filename)
+        if os.path.exists(path):
+            yield catalog, path

--- a/scripts/mongo/report.py
+++ b/scripts/mongo/report.py
@@ -1,0 +1,249 @@
+"""Integrity findings.
+
+Everything reported here is a pre-existing condition in the content tree, not
+an import bug. Nothing is repaired automatically: the JSON files remain the
+app's delivery mechanism, so a migration that silently "cleans up" data would
+produce a publish diff nobody asked for. The report exists to make these
+visible for the first time; fixing them is content work to do afterwards.
+"""
+
+import collections
+import os
+
+from . import manifest as mf
+
+
+class Finding(object):
+    def __init__(self, kind, severity, message):
+        self.kind = kind
+        self.severity = severity  # "error" | "warning" | "info"
+        self.message = message
+
+    def __repr__(self):
+        return "[%s] %s: %s" % (self.severity.upper(), self.kind, self.message)
+
+
+def _actual_counts(docs):
+    counts = collections.Counter()
+    for doc in docs:
+        counts[(doc["locale"], doc["source_acronym"])] += 1
+    return counts
+
+
+def duplicate_keys(collections_map):
+    findings = []
+    for name in ("monsters", "spells"):
+        seen = collections.Counter(
+            (d["locale"], d["source_acronym"], d["index"]) for d in collections_map[name]
+        )
+        for key, count in sorted(seen.items()):
+            if count > 1:
+                findings.append(Finding(
+                    "duplicate-key", "error",
+                    "%s: %s appears %d times" % (name, ":".join(key), count),
+                ))
+    return findings
+
+
+def missing_translations(collections_map):
+    findings = []
+    for name in ("monsters", "spells", "conditions"):
+        docs = collections_map[name]
+        if name == "conditions":
+            key = lambda d: (d["index"],)
+        else:
+            key = lambda d: (d["source_acronym"], d["index"])
+        base = {key(d) for d in docs if d["locale"] == mf.BASE_LOCALE}
+        for locale in mf.LOCALES:
+            if locale == mf.BASE_LOCALE:
+                continue
+            here = {key(d) for d in docs if d["locale"] == locale}
+            missing = base - here
+            extra = here - base
+            if missing:
+                by_source = collections.Counter(k[0] for k in missing)
+                detail = ", ".join("%s: %d" % (s, n) for s, n in sorted(by_source.items()))
+                findings.append(Finding(
+                    "missing-translation", "warning",
+                    "%s/%s: %d entries exist in %s but not here (%s)"
+                    % (name, locale, len(missing), mf.BASE_LOCALE, detail),
+                ))
+            if extra:
+                findings.append(Finding(
+                    "orphan-translation", "warning",
+                    "%s/%s: %d entries have no %s counterpart"
+                    % (name, locale, len(extra), mf.BASE_LOCALE),
+                ))
+    return findings
+
+
+def declared_vs_actual(collections_map):
+    """Compare the totals written in the source configs against reality.
+
+    Only the "full" catalog is checked. The "basic" catalog deliberately
+    renames acronyms in en-us (MM2024 -> MM, SRD-LEGACY -> SRD) while keeping
+    the 2024 payload counts, so its totals describe different content than its
+    acronyms suggest and a naive comparison would be noise.
+    """
+    findings = []
+    monsters = _actual_counts(collections_map["monsters"])
+    spells = _actual_counts(collections_map["spells"])
+    for src in collections_map["sources"]:
+        if src["catalog"] != "full":
+            continue
+        locale, acronym = src["locale"], src["acronym"]
+        for label, declared_key, actual in (
+            ("monsters", "declared_total_monsters", monsters),
+            ("spells", "declared_total_spells", spells),
+        ):
+            declared = src.get(declared_key)
+            if declared is None:
+                continue
+            real = actual.get((locale, acronym), 0)
+            if declared != real:
+                findings.append(Finding(
+                    "count-mismatch", "warning",
+                    "%s/%s: config declares %d %s, tree has %d"
+                    % (locale, acronym, declared, label, real),
+                ))
+    return findings
+
+
+def acronym_consistency(collections_map):
+    """The acronym inside each document must match the directory it came from."""
+    findings = []
+    seen = collections.defaultdict(collections.Counter)
+    for name in ("monsters", "spells"):
+        for doc in collections_map[name]:
+            embedded = (doc.get("source") or {}).get("acronym")
+            if embedded is not None:
+                seen[(doc["locale"], doc["source_acronym"], name)][embedded] += 1
+    for (locale, acronym, name), counts in sorted(seen.items()):
+        wrong = {k: v for k, v in counts.items() if k != acronym}
+        if wrong:
+            detail = ", ".join("%s x%d" % (k, v) for k, v in sorted(wrong.items()))
+            findings.append(Finding(
+                "acronym-mismatch", "error",
+                "%s/%s/%s: documents carry a different source.acronym (%s)"
+                % (locale, acronym, name, detail),
+            ))
+    return findings
+
+
+def config_coverage(collections_map):
+    findings = []
+    known = set(mf.DIR_TO_ACRONYM.values()) | {mf.VIRTUAL_SOURCE}
+    configured = collections.defaultdict(set)
+    for src in collections_map["sources"]:
+        if src["catalog"] == "full":
+            configured[src["locale"]].add(src["acronym"])
+
+    on_disk = collections.defaultdict(set)
+    for name in ("monsters", "spells"):
+        for doc in collections_map[name]:
+            on_disk[doc["locale"]].add(doc["source_acronym"])
+
+    for locale in mf.LOCALES:
+        undeclared = on_disk[locale] - configured[locale]
+        if undeclared:
+            findings.append(Finding(
+                "source-not-configured", "warning",
+                "%s: content exists for %s but no content-sources.json entry "
+                "exposes it" % (locale, ", ".join(sorted(undeclared))),
+            ))
+        phantom = configured[locale] - on_disk[locale]
+        if phantom:
+            findings.append(Finding(
+                "source-without-content", "info",
+                "%s: config lists %s with no content in the tree"
+                % (locale, ", ".join(sorted(phantom))),
+            ))
+        unknown = configured[locale] - known
+        if unknown:
+            findings.append(Finding(
+                "unknown-acronym", "warning",
+                "%s: config lists %s, which is not a known source directory"
+                % (locale, ", ".join(sorted(unknown))),
+            ))
+    return findings
+
+
+def stale_translations(collections_map):
+    """Translations whose base-locale entry has changed since import.
+
+    Always empty on a first import by construction -- the baseline is stamped
+    from the current en-us content. It becomes meaningful once editing starts.
+    """
+    findings = []
+    for name in ("monsters", "spells"):
+        stale = [
+            d for d in collections_map[name]
+            if d["locale"] != mf.BASE_LOCALE and d.get("translated_from_rev") is None
+        ]
+        if stale:
+            by_locale = collections.Counter(d["locale"] for d in stale)
+            for locale, count in sorted(by_locale.items()):
+                findings.append(Finding(
+                    "untracked-translation", "info",
+                    "%s/%s: %d entries have no %s counterpart to track drift "
+                    "against" % (name, locale, count, mf.BASE_LOCALE),
+                ))
+    return findings
+
+
+def format_fidelity(file_meta):
+    findings = []
+    for meta in file_meta:
+        if not meta.get("format_exact", True):
+            findings.append(Finding(
+                "format-not-reproducible", "error",
+                "%s: formatting could not be reproduced; exporting it would "
+                "reformat the file" % meta["_id"],
+            ))
+    return findings
+
+
+ALL_CHECKS = [
+    duplicate_keys,
+    acronym_consistency,
+    missing_translations,
+    declared_vs_actual,
+    config_coverage,
+    stale_translations,
+]
+
+
+def run(collections_map, file_meta=None):
+    findings = []
+    for check in ALL_CHECKS:
+        findings.extend(check(collections_map))
+    if file_meta is not None:
+        findings.extend(format_fidelity(file_meta))
+    return findings
+
+
+def render(findings):
+    if not findings:
+        return "Integrity report: no findings.\n"
+    order = {"error": 0, "warning": 1, "info": 2}
+    findings = sorted(findings, key=lambda f: (order[f.severity], f.kind, f.message))
+    counts = collections.Counter(f.severity for f in findings)
+    lines = ["", "Integrity report: %s" % ", ".join(
+        "%d %s%s" % (counts[s], s, "" if counts[s] == 1 else "s")
+        for s in ("error", "warning", "info") if counts[s]
+    ), ""]
+    current = None
+    for finding in findings:
+        if finding.kind != current:
+            current = finding.kind
+            lines.append("  %s" % current)
+        lines.append("    %-8s %s" % (finding.severity, finding.message))
+    lines.append("")
+    lines.append("  These are pre-existing conditions in the content tree, not")
+    lines.append("  import failures. Nothing was modified.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def error_count(findings):
+    return sum(1 for f in findings if f.severity == "error")

--- a/scripts/mongo/schemas.py
+++ b/scripts/mongo/schemas.py
@@ -1,0 +1,255 @@
+"""MongoDB $jsonSchema validators.
+
+The enums are taken from the corpus itself rather than from CLAUDE.md, because
+the two disagree in places. Anything the corpus actually contains must pass --
+a validator that rejects existing content would block the editor from saving a
+document it had just loaded.
+"""
+
+MONSTER_TYPES = [
+    "ABERRATION", "BEAST", "CELESTIAL", "CONSTRUCT", "DRAGON", "ELEMENTAL",
+    "FEY", "FIEND", "GIANT", "HUMANOID", "MONSTROSITY", "OOZE", "PLANT",
+    "UNDEAD",
+]
+SIZES = ["Tiny", "Small", "Medium", "Large", "Huge", "Gargantuan"]
+SPEED_TYPES = ["WALK", "BURROW", "CLIMB", "FLY", "SWIM"]
+ABILITY_TYPES = [
+    "STRENGTH", "DEXTERITY", "CONSTITUTION", "INTELLIGENCE", "WISDOM",
+    "CHARISMA",
+]
+# METER is documented and supported by the app but unused: every speed in all
+# three locales is FEET. Kept in the enum so a future metric locale is not
+# blocked by the validator.
+MEASUREMENT_UNITS = ["FEET", "METER"]
+DAMAGE_TYPES = [
+    "ACID", "BLUDGEONING", "COLD", "FIRE", "FORCE", "LIGHTNING", "NECROTIC",
+    "PIERCING", "POISON", "PSYCHIC", "RADIANT", "SLASHING", "THUNDER",
+]
+SPELLCASTING_TYPES = ["INNATE", "SPELLCASTER"]
+SPELL_SCHOOLS = [
+    "ABJURATION", "CONJURATION", "DIVINATION", "ENCHANTMENT", "EVOCATION",
+    "ILLUSION", "NECROMANCY", "TRANSMUTATION",
+]
+LOCALES = ["en-us", "pt-br", "es"]
+
+_STR_OR_NULL = {"bsonType": ["string", "null"]}
+_NUM = {"bsonType": ["double", "int", "long"]}
+
+
+def _damage_dice_array():
+    return {
+        "bsonType": "array",
+        "items": {
+            "bsonType": "object",
+            "properties": {
+                "dice": {"bsonType": "string"},
+                "damage": {
+                    "bsonType": "object",
+                    "properties": {"type": {"enum": DAMAGE_TYPES}},
+                },
+            },
+        },
+    }
+
+
+def _ability_block():
+    """Named abilities, actions, reactions and so on.
+
+    Deliberately permissive about the description key: the corpus splits between
+    `desc` and `description` (special_abilities uses desc 1677 times and
+    description 550 times) and the app falls back between them. Requiring either
+    one would reject roughly a quarter of the existing content. Likewise
+    damage_dices and damage_dices_v2 coexist on 31 actions -- a half-finished
+    migration -- so both are allowed.
+    """
+    return {
+        "bsonType": "array",
+        "items": {
+            "bsonType": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {"bsonType": "string"},
+                "desc": _STR_OR_NULL,
+                "description": _STR_OR_NULL,
+                "attack_bonus": {"bsonType": ["int", "long", "null"]},
+                "damage_dices": _damage_dice_array(),
+                "damage_dices_v2": _damage_dice_array(),
+            },
+        },
+    }
+
+
+MONSTER_SCHEMA = {
+    "bsonType": "object",
+    "required": [
+        "_id", "index", "locale", "source_acronym", "name", "type", "size",
+        "ability_scores", "speed",
+    ],
+    "properties": {
+        "_id": {"bsonType": "string"},
+        "index": {"bsonType": "string"},
+        "locale": {"enum": LOCALES},
+        "source_acronym": {"bsonType": "string"},
+        "name": {"bsonType": "string"},
+        "type": {"enum": MONSTER_TYPES},
+        "size": {"enum": SIZES},
+        "subtype": _STR_OR_NULL,
+        "group": _STR_OR_NULL,
+        "challenge_rating": _NUM,
+        "armor_class": {"bsonType": ["int", "long", "null"]},
+        "hit_points": {"bsonType": ["int", "long", "null"]},
+        "ability_scores": {
+            "bsonType": "array",
+            "minItems": 6,
+            "maxItems": 6,
+            "items": {
+                "bsonType": "object",
+                "required": ["type", "value", "modifier"],
+                "properties": {
+                    "type": {"enum": ABILITY_TYPES},
+                    "value": {"bsonType": ["int", "long"]},
+                    "modifier": {"bsonType": ["int", "long"]},
+                },
+            },
+        },
+        "speed": {
+            "bsonType": "object",
+            "required": ["value"],
+            "properties": {
+                "hover": {"bsonType": ["bool", "null"]},
+                "value": {
+                    "bsonType": "array",
+                    "minItems": 1,
+                    "items": {
+                        "bsonType": "object",
+                        "required": ["type", "measurement_unit", "value"],
+                        "properties": {
+                            "type": {"enum": SPEED_TYPES},
+                            "measurement_unit": {"enum": MEASUREMENT_UNITS},
+                            "value": _NUM,
+                        },
+                    },
+                },
+            },
+        },
+        "special_abilities": _ability_block(),
+        "actions": _ability_block(),
+        "legendary_actions": _ability_block(),
+        "bonus_actions": _ability_block(),
+        "reactions": _ability_block(),
+        "spellcasting": {
+            "bsonType": "array",
+            "items": {
+                "bsonType": "object",
+                "properties": {"type": {"enum": SPELLCASTING_TYPES}},
+            },
+        },
+        "source": {
+            "bsonType": "object",
+            "required": ["name", "acronym"],
+            "properties": {
+                "name": {"bsonType": "string"},
+                "acronym": {"bsonType": "string"},
+            },
+        },
+    },
+}
+
+SPELL_SCHEMA = {
+    "bsonType": "object",
+    "required": ["_id", "index", "locale", "source_acronym", "name", "level", "school"],
+    "properties": {
+        "_id": {"bsonType": "string"},
+        "index": {"bsonType": "string"},
+        "locale": {"enum": LOCALES},
+        "source_acronym": {"bsonType": "string"},
+        "name": {"bsonType": "string"},
+        "level": {"bsonType": ["int", "long"], "minimum": 0, "maximum": 9},
+        "school": {"enum": SPELL_SCHOOLS},
+        "ritual": {"bsonType": "bool"},
+        "concentration": {"bsonType": "bool"},
+        "saving_throw_type": _STR_OR_NULL,
+        "damage_type": _STR_OR_NULL,
+        "higher_level": _STR_OR_NULL,
+        "description": {"bsonType": "string"},
+    },
+}
+
+CONDITION_SCHEMA = {
+    "bsonType": "object",
+    "required": ["_id", "index", "locale", "name", "description"],
+    "properties": {
+        "_id": {"bsonType": "string"},
+        "index": {"bsonType": "string"},
+        "locale": {"enum": LOCALES},
+        "type": {"bsonType": "string"},
+        "name": {"bsonType": "string"},
+        "description": {"bsonType": "string"},
+    },
+}
+
+SOURCE_SCHEMA = {
+    "bsonType": "object",
+    "required": ["_id", "locale", "catalog", "acronym", "source", "isEnabled"],
+    "properties": {
+        "_id": {"bsonType": "string"},
+        "locale": {"enum": LOCALES},
+        "catalog": {"enum": ["full", "basic"]},
+        "acronym": {"bsonType": "string"},
+        "source": {
+            "bsonType": "object",
+            "required": ["name", "acronym"],
+            "properties": {
+                "name": {"bsonType": "string"},
+                "acronym": {"bsonType": "string"},
+                "originalAcronym": {"bsonType": "string"},
+            },
+        },
+        "declared_total_monsters": {"bsonType": ["int", "long"]},
+        "declared_total_spells": {"bsonType": ["int", "long"]},
+        "isEnabled": {"bsonType": "bool"},
+        "isLoreEnabled": {"bsonType": "bool"},
+        "isDefault": {"bsonType": "bool"},
+        "contentVersion": {"bsonType": ["int", "long"]},
+        "coverImageUrl": {"bsonType": "string"},
+        "summary": {"bsonType": "string"},
+    },
+}
+
+VALIDATORS = {
+    "monsters": MONSTER_SCHEMA,
+    "spells": SPELL_SCHEMA,
+    "conditions": CONDITION_SCHEMA,
+    "sources": SOURCE_SCHEMA,
+}
+
+INDEXES = {
+    "monsters": [
+        (["locale", "source_acronym", "index"], {"unique": True, "name": "uq_locale_source_index"}),
+        (["locale", "source_acronym"], {"name": "ix_locale_source"}),
+        (["locale", "type"], {"name": "ix_locale_type"}),
+        (["locale", "challenge_rating"], {"name": "ix_locale_cr"}),
+        (["locale", "index"], {"name": "ix_locale_index"}),
+        (["lineage", "edition"], {"name": "ix_lineage_edition"}),
+    ],
+    "spells": [
+        (["locale", "source_acronym", "index"], {"unique": True, "name": "uq_locale_source_index"}),
+        (["locale", "source_acronym"], {"name": "ix_locale_source"}),
+        (["locale", "level"], {"name": "ix_locale_level"}),
+        (["locale", "school"], {"name": "ix_locale_school"}),
+    ],
+    "conditions": [
+        (["locale", "index"], {"unique": True, "name": "uq_locale_index"}),
+    ],
+    "sources": [
+        (["locale", "catalog", "acronym"], {"unique": True, "name": "uq_locale_catalog_acronym"}),
+    ],
+}
+
+# Text indexes are declared separately: a collection may only have one, and it
+# needs a language override because the default "language" field lookup would
+# collide with nothing here but the locale mix makes stemming unhelpful anyway.
+TEXT_INDEXES = {
+    "monsters": ("name", "tx_name"),
+    "spells": ("name", "tx_name"),
+}

--- a/scripts/mongo/transform.py
+++ b/scripts/mongo/transform.py
@@ -1,0 +1,205 @@
+"""Pure file <-> document mapping. No database involved.
+
+Both directions live here so that round-trip fidelity can be tested without a
+running MongoDB, and so that the future /publish endpoint and the import share
+one definition of the mapping.
+
+The contract: documents_to_files(files_to_documents(x)) reproduces x byte for
+byte. Everything else in this pipeline depends on that holding.
+"""
+
+import hashlib
+import json
+import os
+
+from . import manifest as mf
+
+# Indent widths actually found in the tree: the 2024-era source files were
+# written with 2, everything older with 4. Ordered most-common first.
+INDENT_CANDIDATES = [4, 2, 3, 8, 1]
+DEFAULT_INDENT = 4
+
+
+# --------------------------------------------------------------------------- io
+
+def detect_format(raw, parsed):
+    """Recover the exact formatting of a file we are about to re-emit later.
+
+    Formatting is a per-file property here, not a repo-wide convention, so it
+    is measured rather than assumed. Returns (indent, trailing_newline, exact);
+    exact is False when no candidate reproduces the file, which the caller
+    reports rather than silently reformatting.
+    """
+    trailing = raw.endswith("\n")
+    body = raw[:-1] if trailing else raw
+    for indent in INDENT_CANDIDATES:
+        if json.dumps(parsed, indent=indent, ensure_ascii=False) == body:
+            return indent, trailing, True
+    return DEFAULT_INDENT, trailing, False
+
+
+def read_json_file(path):
+    """Return (parsed, format metadata). Files in this repo disagree about both
+    indent width and the trailing newline, so both are recorded."""
+    with open(path, encoding="utf-8") as handle:
+        raw = handle.read()
+    parsed = json.loads(raw)
+    indent, trailing, exact = detect_format(raw, parsed)
+    return parsed, {"indent": indent, "trailing_newline": trailing, "format_exact": exact}
+
+
+def serialize(payload, indent, trailing_newline):
+    text = json.dumps(payload, indent=indent, ensure_ascii=False)
+    return text + "\n" if trailing_newline else text
+
+
+def content_hash(payload):
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+# ------------------------------------------------------------------- files -> db
+
+def _strip_injected(doc):
+    """The original entry, with this pipeline's additions removed and the
+    surviving keys left in their original order."""
+    return {k: v for k, v in doc.items() if k not in mf.INJECTED_KEYS}
+
+
+def _content_doc(entry, locale, acronym, kind):
+    doc = dict(entry)  # injected keys append, so original order is preserved
+    doc["locale"] = locale
+    doc["source_acronym"] = acronym
+    lineage, edition, role = mf.lineage_for(acronym)
+    doc["lineage"] = lineage
+    doc["edition"] = edition
+    doc["role"] = role
+    doc["_id"] = "%s:%s:%s" % (locale, acronym, entry["index"])
+    return doc
+
+
+def _source_doc(entry, locale, catalog):
+    acronym = entry["source"]["acronym"]
+    doc = {}
+    for key, value in entry.items():
+        doc[mf.SOURCE_FIELD_RENAMES.get(key, key)] = value
+    doc["locale"] = locale
+    doc["catalog"] = catalog
+    doc["acronym"] = acronym
+    doc["_id"] = "%s:%s:%s" % (locale, catalog, acronym)
+    return doc
+
+
+def files_to_documents():
+    """Read the whole content tree.
+
+    Returns (collections, file_meta, duplicates) where collections maps a
+    collection name to a list of documents, file_meta records per-file
+    formatting needed to rebuild the files, and duplicates lists any
+    (file, index) that appeared twice inside a single file.
+    """
+    collections = {"monsters": [], "spells": [], "conditions": [], "sources": []}
+    file_meta = []
+    duplicates = []
+
+    def load_entries(path):
+        entries, fmt = read_json_file(path)
+        meta = {"_id": mf.rel(path)}
+        meta.update(fmt)
+        file_meta.append(meta)
+        return entries
+
+    for locale in mf.LOCALES:
+        for kind in ("monsters", "spells"):
+            for acronym, path in mf.content_files(locale, kind):
+                seen = set()
+                for entry in load_entries(path):
+                    if entry["index"] in seen:
+                        duplicates.append((mf.rel(path), entry["index"]))
+                    seen.add(entry["index"])
+                    collections[kind].append(_content_doc(entry, locale, acronym, kind))
+
+        conditions_path = mf.conditions_file(locale)
+        if os.path.exists(conditions_path):
+            for entry in load_entries(conditions_path):
+                doc = dict(entry)
+                doc["locale"] = locale
+                doc["_id"] = "%s:%s" % (locale, entry["index"])
+                collections["conditions"].append(doc)
+
+        for catalog, path in mf.source_config_files(locale):
+            for entry in load_entries(path):
+                collections["sources"].append(_source_doc(entry, locale, catalog))
+
+    _attach_translation_revisions(collections)
+    return collections, file_meta, duplicates
+
+
+def _attach_translation_revisions(collections):
+    """Stamp non-base-locale content with the hash of the base-locale entry it
+    corresponds to.
+
+    Missing translations are already findable with a set difference. Stale ones
+    -- English edited after the translation was written -- are invisible without
+    this, and that is the failure mode that ships wrong content. On a first
+    import every existing translation is stamped as current; that is a baseline
+    to measure future drift against, not a claim that it is accurate today.
+    """
+    for kind in ("monsters", "spells"):
+        base = {}
+        for doc in collections[kind]:
+            if doc["locale"] == mf.BASE_LOCALE:
+                key = (doc["source_acronym"], doc["index"])
+                base[key] = content_hash(_strip_injected(doc))
+        for doc in collections[kind]:
+            if doc["locale"] == mf.BASE_LOCALE:
+                continue
+            key = (doc["source_acronym"], doc["index"])
+            doc["translated_from_rev"] = base.get(key)
+
+
+# ------------------------------------------------------------------- db -> files
+
+def _unsource_doc(doc):
+    inverse = {v: k for k, v in mf.SOURCE_FIELD_RENAMES.items()}
+    return {inverse.get(k, k): v for k, v in doc.items() if k not in mf.INJECTED_KEYS}
+
+
+def documents_to_files(collections, file_meta):
+    """Rebuild the content tree. Returns {repo-relative path: file text}."""
+    fmt = {m["_id"]: m for m in file_meta}
+    grouped = {}
+
+    def add(path, entry):
+        grouped.setdefault(mf.rel(path), []).append(entry)
+
+    for locale in mf.LOCALES:
+        for kind in ("monsters", "spells"):
+            by_key = {}
+            for doc in collections.get(kind, []):
+                if doc["locale"] == locale:
+                    by_key.setdefault(doc["source_acronym"], []).append(doc)
+            for acronym, path in mf.content_files(locale, kind):
+                for doc in by_key.get(acronym, []):
+                    add(path, _strip_injected(doc))
+
+        conditions_path = mf.conditions_file(locale)
+        if os.path.exists(conditions_path):
+            for doc in collections.get("conditions", []):
+                if doc["locale"] == locale:
+                    add(conditions_path, _strip_injected(doc))
+
+        for catalog, path in mf.source_config_files(locale):
+            for doc in collections.get("sources", []):
+                if doc["locale"] == locale and doc["catalog"] == catalog:
+                    add(path, _unsource_doc(doc))
+
+    out = {}
+    for path, entries in grouped.items():
+        meta = fmt.get(path, {})
+        out[path] = serialize(
+            entries,
+            meta.get("indent", DEFAULT_INDENT),
+            meta.get("trailing_newline", False),
+        )
+    return out

--- a/scripts/mongo/verify.py
+++ b/scripts/mongo/verify.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Offline checks that need no database.
+
+Two things are worth proving before any server is involved:
+
+  1. Round trip -- documents_to_files(files_to_documents(tree)) reproduces every
+     file byte for byte. If this fails, publishing would silently reformat or
+     lose content.
+  2. Validator fit -- every document already in the tree satisfies the
+     $jsonSchema that import.py is about to attach. A validator that rejects
+     existing content would let the editor load a monster it cannot save.
+
+    python3 scripts/mongo/verify.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from mongo import manifest as mf     # noqa: E402
+from mongo import report as reportmod  # noqa: E402
+from mongo import schemas            # noqa: E402
+from mongo import transform          # noqa: E402
+
+# Enough of the BSON type vocabulary to interpret the validators in schemas.py.
+BSON_TYPES = {
+    "string": str,
+    "object": dict,
+    "array": list,
+    "bool": bool,
+    "null": type(None),
+    "int": int,
+    "long": int,
+    "double": float,
+    "decimal": float,
+}
+
+
+def _matches_type(value, names):
+    if isinstance(names, str):
+        names = [names]
+    for name in names:
+        expected = BSON_TYPES.get(name)
+        if expected is None:
+            continue
+        # bool is a subclass of int in Python but a distinct BSON type.
+        if isinstance(value, bool) and expected is not bool:
+            continue
+        if expected is float and isinstance(value, int) and not isinstance(value, bool):
+            continue
+        if isinstance(value, expected):
+            return True
+    return False
+
+
+def validate(value, schema, path=""):
+    """Return a list of human-readable violations of the schema subset used here."""
+    errors = []
+    if "bsonType" in schema and not _matches_type(value, schema["bsonType"]):
+        errors.append("%s: expected %s, got %s"
+                      % (path or "<root>", schema["bsonType"], type(value).__name__))
+        return errors
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append("%s: %r not in enum" % (path or "<root>", value))
+        return errors
+
+    if isinstance(value, dict):
+        for key in schema.get("required", []):
+            if key not in value:
+                errors.append("%s: missing required field %r" % (path or "<root>", key))
+        for key, subschema in schema.get("properties", {}).items():
+            if key in value:
+                errors.extend(validate(value[key], subschema,
+                                       "%s.%s" % (path, key) if path else key))
+    elif isinstance(value, list):
+        if "minItems" in schema and len(value) < schema["minItems"]:
+            errors.append("%s: %d items, minimum %d" % (path, len(value), schema["minItems"]))
+        if "maxItems" in schema and len(value) > schema["maxItems"]:
+            errors.append("%s: %d items, maximum %d" % (path, len(value), schema["maxItems"]))
+        if "items" in schema:
+            for position, item in enumerate(value):
+                errors.extend(validate(item, schema["items"], "%s[%d]" % (path, position)))
+    else:
+        if "minimum" in schema and value < schema["minimum"]:
+            errors.append("%s: %r below minimum %r" % (path, value, schema["minimum"]))
+        if "maximum" in schema and value > schema["maximum"]:
+            errors.append("%s: %r above maximum %r" % (path, value, schema["maximum"]))
+    return errors
+
+
+def check_roundtrip(collections_map, file_meta):
+    rebuilt = transform.documents_to_files(collections_map, file_meta)
+    read_paths = {m["_id"] for m in file_meta}
+    problems = []
+    for relpath in sorted(read_paths - set(rebuilt)):
+        problems.append("%s: read but not rebuilt" % relpath)
+    for relpath in sorted(set(rebuilt) - read_paths):
+        problems.append("%s: rebuilt but never read" % relpath)
+    identical = 0
+    for relpath, text in sorted(rebuilt.items()):
+        with open(os.path.join(mf.REPO_ROOT, relpath), encoding="utf-8") as handle:
+            if handle.read() == text:
+                identical += 1
+            else:
+                problems.append("%s: differs after round trip" % relpath)
+    return identical, len(rebuilt), problems
+
+
+def check_validators(collections_map):
+    results = {}
+    for name, schema in schemas.VALIDATORS.items():
+        failures = []
+        for doc in collections_map[name]:
+            errors = validate(doc, schema)
+            if errors:
+                failures.append((doc["_id"], errors))
+        results[name] = failures
+    return results
+
+
+def main():
+    print("Reading content tree from %s" % mf.JSON_ROOT)
+    collections_map, file_meta, duplicates = transform.files_to_documents()
+    failed = False
+
+    print("\n1. Round trip")
+    identical, total, problems = check_roundtrip(collections_map, file_meta)
+    print("   %d / %d files byte-identical" % (identical, total))
+    for problem in problems[:20]:
+        print("   FAIL %s" % problem)
+    if problems:
+        failed = True
+
+    print("\n2. Validator fit")
+    results = check_validators(collections_map)
+    for name in ("monsters", "spells", "conditions", "sources"):
+        failures = results[name]
+        total_docs = len(collections_map[name])
+        if failures:
+            failed = True
+            print("   %-11s %d / %d documents REJECTED" % (name, len(failures), total_docs))
+            for doc_id, errors in failures[:5]:
+                print("     %s" % doc_id)
+                for error in errors[:3]:
+                    print("       %s" % error)
+        else:
+            print("   %-11s all %d documents accepted" % (name, total_docs))
+
+    print("\n3. Key uniqueness")
+    if duplicates:
+        failed = True
+        for path, index in duplicates[:10]:
+            print("   FAIL duplicate index %r in %s" % (index, path))
+    else:
+        print("   no duplicate keys within any file")
+
+    print(reportmod.render(reportmod.run(collections_map, file_meta)))
+    print("RESULT: %s" % ("FAILED" if failed else "PASSED"))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Groundwork for the backend API and the web editing frontend. Loads monsters, spells, conditions and source configs into MongoDB.

The app keeps consuming the JSON files, so **MongoDB is the editing source of truth and the files stay the delivery mechanism**. `export.py` regenerates the tree and is the code path a future `/publish` endpoint should reuse.

## What's here

```
compose.yaml                 local Mongo (dev only; production uses a managed instance)
scripts/mongo/manifest.py    locales, dir->acronym, edition lineage, file discovery
scripts/mongo/transform.py   files <-> documents, no DB, so fidelity is testable offline
scripts/mongo/schemas.py     $jsonSchema validators + index specs
scripts/mongo/report.py      integrity findings
scripts/mongo/db.py          connection, indexes, collMod, bulk upsert
scripts/mongo/{import,export,verify}.py
```

| Collection | Docs | `_id` |
|---|---|---|
| `monsters` | 4,207 | `<locale>:<source_acronym>:<index>` |
| `spells` | 2,196 | `<locale>:<source_acronym>:<index>` |
| `conditions` | 45 | `<locale>:<index>` |
| `sources` | 41 | `<locale>:<catalog>:<acronym>` |
| `_file_meta` | 57 | repo-relative path |

## The constraint that shaped it

**The round trip is byte-exact.** All 57 files are reproduced exactly. Without that, publishing one edit would reformat unrelated content. Two findings fell out of enforcing it:

- **Formatting is per-file, not repo-wide.** The 2024-era sources (`mm2024`, `srd2024`, `srd-legacy`, `mm-legacy`, `phb2024`) use `indent=2`; everything older uses `indent=4`. An early version assumed `indent=4` everywhere and corrupted 14 files. Indent and trailing newline are now measured into `_file_meta`, and `export.py` refuses to run without it.
- **`index` alone is not unique.** 417 monster indexes in `en-us` appear in more than one source — `bugbear-chief` is in `MM`, `MM-LEGACY` and `SRD2024`. Hence the composite key, which is also what makes the import idempotent.

## Reviewer notes

**Derived fields** are added on import and stripped on export: `locale` / `source_acronym` from tree position; `lineage` / `edition` / `role`, because the `*-LEGACY` sources are *deltas* holding entries dropped from the 2024 edition rather than full 2014 catalogs; and `translated_from_rev`, a hash of the `en-us` entry a translation came from — missing translations are already a set difference, but stale ones are invisible without it.

**Two inconsistencies are preserved, not normalised.** `desc` vs `description` (1,677 vs 550 in `special_abilities`) and `damage_dices` vs `damage_dices_v2` (31 actions carry both). The Android app falls back between them, so normalising needs its parser checked first. Validators accept either form; all 4,207 monsters pass.

**Source configs come from `content-sources.json`**, not the superseded `default-sources.json` / `alternative-sources.json` / `alternative-sources-basic.json` trio — `content-sources.json` is their union plus the 2024 entries. Worth knowing: `CLAUDE.md` still documents the old pair and is a generation stale.

**`totalMonsters` is imported as `declared_total_monsters`** so nothing in the database looks authoritative when it isn't. The real count is an aggregation over `monsters`; the import reports where they disagree.

**Exit codes:** `import.py` fails only when the *import* fails (duplicate keys in a file, a validator that couldn't be applied). Integrity findings describe the content tree, not the run, so they don't fail it — otherwise every run would report failure until unrelated content got edited. `--strict` opts in.

## Verification

`python3 scripts/mongo/verify.py` → **PASSED**, and against a live Mongo 8:

- Counts: 4,207 / 2,196 / 45 / 41 as expected
- Round trip: **57/57 byte-identical** through real BSON
- Idempotency: second run 0 inserted / 4,207 replaced; `--drop` rebuild clean
- Validators: 10 invalid cases rejected server-side, 6 valid accepted (including the tolerated `desc` and `damage_dices_v2` variants); unique index enforcing
- Collisions: `bugbear-chief` resolves to 3 independently addressable documents

## Content fix included

Second commit fixes `json/pt-br/sources/psb3/monsters.json`, where one entry carried `source.acronym: "BEJ3"` — the acronym had been translated along with the source name. It was the only error the integrity report found; the remaining 9 findings are warnings (count drift in `en-us`/`es`, 17 monsters missing from `pt-br`, and `es` shipping 2024 content no `es` config exposes).

## Not included

Lore (~6,000 entries; lore sources are a separate taxonomy of 38 adventure books, and lore covers 703 monster indexes with no stat block), images (`monster-images.json`, locale-independent), and the legacy root `json/monsters.json` / `json/spells.json` (last touched 2023 and 2022, strict subsets of the locale files). The Ktor service and `/publish` endpoint come next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
