### PR TITLE
Import monster lore and images into MongoDB

### DIFF
--- a/scripts/mongo/README.md
+++ b/scripts/mongo/README.md
@@ -6,8 +6,15 @@ the delivery mechanism** — the database is the editing source of truth, and
 `export.py` regenerates the tree.
 
 Everything here is built around one property: **the round trip is byte-exact.**
-`export.py` reproduces all 57 files exactly as they are on disk. Without that,
-publishing an edit would also reformat unrelated content.
+`export.py` reproduces 175 of the 176 managed files exactly as they are on
+disk. Without that, publishing an edit would also reformat unrelated content.
+
+The one exception is `json/en-us/lore/erlw/monster-lore.json`, which has
+hand-edited indentation (two array elements at 8 spaces instead of 4) that no
+serializer setting emits. It is recorded as `format_exact: false` and will be
+reindented on the first publish — a 2-line whitespace-only diff. Both
+`verify.py` and `export.py --check` report it as a known normalisation rather
+than a failure.
 
 ## Setup
 
@@ -32,22 +39,46 @@ python3 scripts/mongo/import.py
 
 ## Collections
 
-| Collection | Docs | `_id` |
-|---|---|---|
-| `monsters` | 4,207 | `<locale>:<source_acronym>:<index>` |
-| `spells` | 2,196 | `<locale>:<source_acronym>:<index>` |
-| `conditions` | 45 | `<locale>:<index>` |
-| `sources` | 41 | `<locale>:<catalog>:<acronym>` |
-| `_file_meta` | 57 | repo-relative path |
+| Collection | Docs | `_id` | Locale-scoped |
+|---|---|---|---|
+| `monsters` | 4,207 | `<locale>:<source_acronym>:<index>` | yes |
+| `spells` | 2,196 | `<locale>:<source_acronym>:<index>` | yes |
+| `conditions` | 45 | `<locale>:<index>` | yes |
+| `sources` | 41 | `<locale>:<catalog>:<acronym>` | yes |
+| `monster_lore` | 5,965 | `<locale>:<lore_source>:<index>` | yes |
+| `monster_images` | 1,345 | `<catalog>:<monster_index>` | **no** |
+| `_file_meta` | 176 | repo-relative path | — |
 
 `index` alone is **not** unique: 113 monster indexes appear in more than one
 source (`bugbear-chief` is in `MM`, `MM-LEGACY` and `SRD2024`). The composite
 key is the reason the import can be idempotent.
 
-`_file_meta` records per-file indent width and trailing newline. The tree is not
-formatted consistently — the 2024-era sources use `indent=2`, everything older
-uses `indent=4` — so this is measured on import rather than assumed. **Export
-cannot reproduce the files without it.**
+Lore keys need the book for the same reason monsters need the source: **333
+lore indexes appear in more than one book** (`azer` has lore in `mtf`,
+`mm2024` and `mm`).
+
+`_file_meta` records per-file serialization style, indent width and the exact
+trailing whitespace run. The tree is not formatted consistently — the 2024-era
+sources use `indent=2`, everything older `indent=4`, the legacy aggregated lore
+files are minified, one file ends with a newline plus sixteen spaces, and six
+empty lore books are written `[\n]` rather than `[]`. All of it is measured on
+import rather than assumed. **Export cannot reproduce the files without it.**
+
+## Lore and images
+
+**Lore books are a separate taxonomy from content sources.** 40 directories,
+mostly adventure titles, of which only 8 are also content sources. 698 lore
+indexes describe monsters that have no stat block anywhere in the tree, so
+lore cannot be modelled as a property of a monster.
+
+**The two image catalogs are not a set and its subset.** `monster-images.json`
+(`default`, 1,023) and `monster-images-srd.json` (`srd`, 322) share 322
+`monster_index` values and **disagree on the `image_url` for 298 of them** —
+`default` points at `srd-v2/`, `srd` at `images/`. They are separate art sets;
+merging them would silently drop one.
+
+Images carry **no `locale`** and are keyed by `monster_index` alone: one image
+serves a monster across every locale and every source that reprints it.
 
 ### Derived fields
 
@@ -107,10 +138,21 @@ content tree, not the run, so they do not fail it — otherwise every run would
 report failure until unrelated content is edited. Pass `--strict` in a pipeline
 that should block on them.
 
-## Not yet imported
+## Deliberately unmanaged
 
-Lore (~6,000 entries; lore sources are a separate taxonomy of 38 adventure
-books, and lore covers 703 monster indexes with no stat block), images
-(`json/monster-images.json`, 1,023 entries, locale-independent), and the legacy
-root files `json/monsters.json` / `json/spells.json` (last touched 2023 and
-2022, strict subsets of the locale files).
+Export never writes these, so app versions pinned to them keep reading exactly
+what is there today:
+
+- `json/monsters.json`, `json/spells.json` — superseded by the locale-scoped
+  files; last touched 2023 and 2022.
+- `json/<locale>/monster-lore.json` — a stale January-2023 aggregate. A list of
+  38 lists whose group order matches no config, holding 1,476 of the
+  directories' 1,988 entries, missing `erlw`/`mm2024`/`psb3` entirely,
+  byte-identical between `en-us` and `pt-br` (never translated), and absent for
+  `es`.
+- `json/monster-lore-sources.json` — legacy, no longer read by the app. It was
+  the only place mapping lore acronyms to book names, so **32 of the 40 lore
+  books currently have no display name anywhere** in the repo. Authoring those
+  is content work, not migration work.
+- `json/alternative-sources.json`, `default-sources.json`,
+  `alternative-sources-basic.json` — superseded by `content-sources.json`.

--- a/scripts/mongo/export.py
+++ b/scripts/mongo/export.py
@@ -21,7 +21,8 @@ from mongo import db as dbmod        # noqa: E402
 from mongo import manifest as mf     # noqa: E402
 from mongo import transform          # noqa: E402
 
-COLLECTIONS = ["monsters", "spells", "conditions", "sources"]
+COLLECTIONS = ["monsters", "spells", "conditions", "sources",
+               "monster_lore", "monster_images"]
 
 
 def load_from_db(database):
@@ -49,9 +50,15 @@ def write_tree(rebuilt, out_root):
             handle.write(text)
 
 
-def check(rebuilt, show_diff=False):
-    """Compare against the working tree. Returns the list of differing paths."""
-    differing = []
+def check(rebuilt, file_meta, show_diff=False):
+    """Compare against the working tree.
+
+    Returns (unexpected, expected). A file whose formatting was recorded as not
+    reproducible will always come back reindented, so it is separated out --
+    otherwise this check would be permanently red for a known, accepted reason.
+    """
+    inexact = {m["_id"] for m in file_meta if not m.get("format_exact", True)}
+    differing, expected = [], []
     for relpath, text in sorted(rebuilt.items()):
         original_path = os.path.join(mf.REPO_ROOT, relpath)
         if not os.path.exists(original_path):
@@ -60,7 +67,7 @@ def check(rebuilt, show_diff=False):
         with open(original_path, encoding="utf-8") as handle:
             original = handle.read()
         if text != original:
-            differing.append(relpath)
+            (expected if relpath in inexact else differing).append(relpath)
             if show_diff:
                 diff = difflib.unified_diff(
                     original.splitlines(True), text.splitlines(True),
@@ -68,7 +75,7 @@ def check(rebuilt, show_diff=False):
                     tofile=relpath + " (from database)", n=1,
                 )
                 sys.stdout.writelines(list(diff)[:40])
-    return differing
+    return differing, expected
 
 
 def main(argv=None):
@@ -93,13 +100,17 @@ def main(argv=None):
     print("Rebuilt %d files" % len(rebuilt))
 
     if args.check:
-        differing = check(rebuilt, args.diff)
+        differing, expected = check(rebuilt, file_meta, args.diff)
+        for relpath in expected:
+            print("  reindented (formatting was not reproducible): %s" % relpath)
         if differing:
-            print("\n%d file(s) differ from the working tree:" % len(differing))
+            print("\n%d file(s) differ unexpectedly from the working tree:"
+                  % len(differing))
             for relpath in differing:
                 print("  %s" % relpath)
             return 1
-        print("\nAll %d files are byte-identical to the working tree." % len(rebuilt))
+        print("\n%d of %d files byte-identical; %d reindented as recorded."
+              % (len(rebuilt) - len(expected), len(rebuilt), len(expected)))
         return 0
 
     out_root = mf.REPO_ROOT if args.in_place else args.out

--- a/scripts/mongo/import.py
+++ b/scripts/mongo/import.py
@@ -21,7 +21,8 @@ from mongo import report as reportmod  # noqa: E402
 from mongo import schemas              # noqa: E402
 from mongo import transform            # noqa: E402
 
-COLLECTIONS = ["monsters", "spells", "conditions", "sources"]
+COLLECTIONS = ["monsters", "spells", "conditions", "sources",
+               "monster_lore", "monster_images"]
 
 
 def parse_args(argv=None):

--- a/scripts/mongo/manifest.py
+++ b/scripts/mongo/manifest.py
@@ -71,6 +71,7 @@ INJECTED_KEYS = [
     "_id",
     "locale",
     "source_acronym",
+    "lore_source",
     "catalog",
     "acronym",
     "lineage",
@@ -86,6 +87,34 @@ SOURCE_FIELD_RENAMES = {
     "totalMonsters": "declared_total_monsters",
     "totalSpells": "declared_total_spells",
 }
+
+# The two image catalogs. These are NOT one set and a subset of it: they share
+# 322 monster_index values and 311 of those differ, because the files point at
+# different art (images/ versus srd-v2/). Merging them would silently drop one
+# set, so each is imported under its own catalog.
+IMAGE_CATALOGS = {
+    "default": "monster-images.json",
+    "srd": "monster-images-srd.json",
+}
+
+# Files left unmanaged on purpose. Export never writes them, so old app
+# versions pinned to these paths keep reading exactly what is there today.
+#
+#   monsters.json, spells.json      superseded by the locale-scoped files
+#                                   (last touched 2023 and 2022)
+#   <locale>/monster-lore.json      a stale 2023 aggregate: 38 groups in an
+#                                   order that matches no config, 1476 of the
+#                                   directories' 1988 entries, missing erlw,
+#                                   mm2024 and psb3, never translated
+#   monster-lore-sources.json       legacy, no longer read by the app
+#   alternative-sources*.json,      superseded by content-sources.json
+#   default-sources.json
+LEGACY_UNMANAGED = [
+    "json/monsters.json",
+    "json/spells.json",
+    "json/monster-lore-sources.json",
+    "json/alternative-sources.json",
+]
 
 FILE_META_COLLECTION = "_file_meta"
 
@@ -129,5 +158,31 @@ def conditions_file(locale):
 def source_config_files(locale):
     for catalog, filename in SOURCE_CONFIGS:
         path = os.path.join(locale_dir(locale), filename)
+        if os.path.exists(path):
+            yield catalog, path
+
+
+def lore_files(locale):
+    """Yield (lore_source, absolute path) for every lore book in a locale.
+
+    Discovered from disk rather than from a table: the set differs per locale
+    (pt-br has no llk/lr/tce directories) and lore books are their own
+    taxonomy -- 40 mostly-adventure titles, only 8 of which are also content
+    sources. The locale-root monster-lore.json is deliberately excluded, see
+    LEGACY_UNMANAGED.
+    """
+    root = os.path.join(locale_dir(locale), "lore")
+    if not os.path.isdir(root):
+        return
+    for name in sorted(os.listdir(root)):
+        path = os.path.join(root, name, "monster-lore.json")
+        if os.path.exists(path):
+            yield name, path
+
+
+def image_files():
+    """Yield (catalog, absolute path). Images are global -- not locale-scoped."""
+    for catalog in sorted(IMAGE_CATALOGS):
+        path = os.path.join(JSON_ROOT, IMAGE_CATALOGS[catalog])
         if os.path.exists(path):
             yield catalog, path

--- a/scripts/mongo/report.py
+++ b/scripts/mongo/report.py
@@ -47,12 +47,14 @@ def duplicate_keys(collections_map):
 
 def missing_translations(collections_map):
     findings = []
-    for name in ("monsters", "spells", "conditions"):
+    scopes = {"monsters": "source_acronym", "spells": "source_acronym",
+              "conditions": None, "monster_lore": "lore_source"}
+    for name, scope_field in scopes.items():
         docs = collections_map[name]
-        if name == "conditions":
+        if scope_field is None:
             key = lambda d: (d["index"],)
         else:
-            key = lambda d: (d["source_acronym"], d["index"])
+            key = lambda d, f=scope_field: (d[f], d["index"])
         base = {key(d) for d in docs if d["locale"] == mf.BASE_LOCALE}
         for locale in mf.LOCALES:
             if locale == mf.BASE_LOCALE:
@@ -175,7 +177,7 @@ def stale_translations(collections_map):
     from the current en-us content. It becomes meaningful once editing starts.
     """
     findings = []
-    for name in ("monsters", "spells"):
+    for name in ("monsters", "spells", "monster_lore"):
         stale = [
             d for d in collections_map[name]
             if d["locale"] != mf.BASE_LOCALE and d.get("translated_from_rev") is None
@@ -196,10 +198,82 @@ def format_fidelity(file_meta):
     for meta in file_meta:
         if not meta.get("format_exact", True):
             findings.append(Finding(
-                "format-not-reproducible", "error",
-                "%s: formatting could not be reproduced; exporting it would "
-                "reformat the file" % meta["_id"],
+                "format-not-reproducible", "warning",
+                "%s: hand-edited formatting that no serializer emits; export "
+                "will reindent it" % meta["_id"],
             ))
+    return findings
+
+
+def lore_coverage(collections_map):
+    """Lore books present per locale, and lore that describes no stat block."""
+    findings = []
+    books = collections.defaultdict(set)
+    for doc in collections_map["monster_lore"]:
+        books[doc["locale"]].add(doc["lore_source"])
+    base_books = books[mf.BASE_LOCALE]
+    for locale in mf.LOCALES:
+        missing = base_books - books[locale]
+        if missing:
+            findings.append(Finding(
+                "lore-book-missing", "warning",
+                "%s: no lore directory for %s"
+                % (locale, ", ".join(sorted(missing))),
+            ))
+
+    monster_indexes = {d["index"] for d in collections_map["monsters"]}
+    orphan = {d["index"] for d in collections_map["monster_lore"]} - monster_indexes
+    if orphan:
+        findings.append(Finding(
+            "lore-without-monster", "info",
+            "%d lore indexes describe monsters with no stat block in any "
+            "source" % len(orphan),
+        ))
+    return findings
+
+
+def image_coverage(collections_map):
+    findings = []
+    images = collections_map["monster_images"]
+    monster_indexes = {d["index"] for d in collections_map["monsters"]}
+    image_indexes = {d["monster_index"] for d in images}
+
+    orphan = image_indexes - monster_indexes
+    if orphan:
+        findings.append(Finding(
+            "image-without-monster", "info",
+            "%d image entries reference an index with no stat block"
+            % len(orphan),
+        ))
+    base_monsters = {d["index"] for d in collections_map["monsters"]
+                     if d["locale"] == mf.BASE_LOCALE}
+    missing = base_monsters - image_indexes
+    if missing:
+        findings.append(Finding(
+            "monster-without-image", "warning",
+            "%d monsters have no image in either catalog (%s%s)"
+            % (len(missing), ", ".join(sorted(missing)[:5]),
+               ", ..." if len(missing) > 5 else ""),
+        ))
+
+    # The two catalogs are independent art sets, not a set and its subset.
+    by_catalog = collections.defaultdict(set)
+    for doc in images:
+        by_catalog[doc["catalog"]].add(doc["monster_index"])
+    catalogs = sorted(by_catalog)
+    if len(catalogs) == 2:
+        shared = by_catalog[catalogs[0]] & by_catalog[catalogs[1]]
+        urls = collections.defaultdict(dict)
+        for doc in images:
+            urls[doc["monster_index"]][doc["catalog"]] = doc["image_url"]
+        differing = sum(1 for i in shared
+                        if urls[i][catalogs[0]] != urls[i][catalogs[1]])
+        findings.append(Finding(
+            "image-catalogs-diverge", "info",
+            "%s and %s share %d indexes and disagree on %d of them; they are "
+            "separate art sets, not a subset"
+            % (catalogs[0], catalogs[1], len(shared), differing),
+        ))
     return findings
 
 
@@ -209,6 +283,8 @@ ALL_CHECKS = [
     missing_translations,
     declared_vs_actual,
     config_coverage,
+    lore_coverage,
+    image_coverage,
     stale_translations,
 ]
 

--- a/scripts/mongo/schemas.py
+++ b/scripts/mongo/schemas.py
@@ -216,11 +216,64 @@ SOURCE_SCHEMA = {
     },
 }
 
+LORE_SCHEMA = {
+    "bsonType": "object",
+    "required": ["_id", "index", "locale", "lore_source", "entries"],
+    "properties": {
+        "_id": {"bsonType": "string"},
+        "index": {"bsonType": "string"},
+        "locale": {"enum": LOCALES},
+        "lore_source": {"bsonType": "string"},
+        "entries": {
+            "bsonType": "array",
+            "minItems": 1,
+            "items": {
+                "bsonType": "object",
+                # description is the body of a lore paragraph and is always
+                # present; title is optional, marking a sub-heading.
+                "required": ["description"],
+                "properties": {
+                    "description": {"bsonType": "string"},
+                    "title": {"bsonType": "string"},
+                },
+            },
+        },
+        "translated_from_rev": {"bsonType": ["string", "null"]},
+    },
+}
+
+# Images are global: no locale field, and keyed by monster_index alone rather
+# than by the (locale, source, index) triple monsters use. One image serves the
+# same monster across every locale and every source that reprints it.
+IMAGE_SCHEMA = {
+    "bsonType": "object",
+    "required": ["_id", "monster_index", "catalog", "background_color", "image_url"],
+    "properties": {
+        "_id": {"bsonType": "string"},
+        "monster_index": {"bsonType": "string"},
+        "catalog": {"enum": ["default", "srd"]},
+        "background_color": {
+            "bsonType": "object",
+            "required": ["light", "dark"],
+            "properties": {
+                "light": {"bsonType": "string"},
+                "dark": {"bsonType": "string"},
+            },
+        },
+        "image_url": {"bsonType": "string"},
+        "is_horizontal_image": {"bsonType": "bool"},
+        # Absent on 26 of the 322 SRD entries, so it cannot be required.
+        "content_scale": {"enum": ["Crop", "Fit"]},
+    },
+}
+
 VALIDATORS = {
     "monsters": MONSTER_SCHEMA,
     "spells": SPELL_SCHEMA,
     "conditions": CONDITION_SCHEMA,
     "sources": SOURCE_SCHEMA,
+    "monster_lore": LORE_SCHEMA,
+    "monster_images": IMAGE_SCHEMA,
 }
 
 INDEXES = {
@@ -243,6 +296,17 @@ INDEXES = {
     ],
     "sources": [
         (["locale", "catalog", "acronym"], {"unique": True, "name": "uq_locale_catalog_acronym"}),
+    ],
+    "monster_lore": [
+        (["locale", "lore_source", "index"], {"unique": True, "name": "uq_locale_book_index"}),
+        # "all lore for this monster" spans books: 333 indexes appear in more
+        # than one, so this is the query the editor actually needs.
+        (["locale", "index"], {"name": "ix_locale_index"}),
+        (["locale", "lore_source"], {"name": "ix_locale_book"}),
+    ],
+    "monster_images": [
+        (["catalog", "monster_index"], {"unique": True, "name": "uq_catalog_monster"}),
+        (["monster_index"], {"name": "ix_monster_index"}),
     ],
 }
 

--- a/scripts/mongo/transform.py
+++ b/scripts/mongo/transform.py
@@ -14,43 +14,70 @@ import os
 
 from . import manifest as mf
 
-# Indent widths actually found in the tree: the 2024-era source files were
-# written with 2, everything older with 4. Ordered most-common first.
+# Serialization styles found in the tree. The content files are not formatted
+# consistently -- the 2024-era sources use indent=2, everything older uses 4,
+# the legacy aggregated lore files are minified, and a handful carry stray
+# trailing whitespace. Formatting is therefore measured per file, never assumed.
 INDENT_CANDIDATES = [4, 2, 3, 8, 1]
 DEFAULT_INDENT = 4
+
+STYLE_INDENT = "indent"
+STYLE_COMPACT = "compact"          # separators=(",", ":")
+STYLE_COMPACT_SPACED = "compact-spaced"  # separators=(", ", ": ")
+STYLE_EMPTY_NEWLINE = "empty-newline"    # the literal text "[\n]"
+
+EMPTY_NEWLINE_TEXT = "[\n]"
 
 
 # --------------------------------------------------------------------------- io
 
-def detect_format(raw, parsed):
-    """Recover the exact formatting of a file we are about to re-emit later.
+def _render(payload, style, indent):
+    if style == STYLE_COMPACT:
+        return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    if style == STYLE_COMPACT_SPACED:
+        return json.dumps(payload, separators=(", ", ": "), ensure_ascii=False)
+    if style == STYLE_EMPTY_NEWLINE:
+        return EMPTY_NEWLINE_TEXT
+    return json.dumps(payload, indent=indent, ensure_ascii=False)
 
-    Formatting is a per-file property here, not a repo-wide convention, so it
-    is measured rather than assumed. Returns (indent, trailing_newline, exact);
-    exact is False when no candidate reproduces the file, which the caller
-    reports rather than silently reformatting.
+
+def detect_format(raw, parsed):
+    """Recover the exact formatting of a file we may have to re-emit later.
+
+    Returns a dict with style, indent, trailing and format_exact. trailing is
+    the literal whitespace run at end of file, not a boolean: one file ends
+    with a newline followed by sixteen spaces, and a bool cannot carry that.
+
+    format_exact is False when no candidate reproduces the file. The caller
+    reports those rather than pretending the round trip is lossless -- one file
+    in the tree has hand-edited indentation that no serializer setting emits.
     """
-    trailing = raw.endswith("\n")
-    body = raw[:-1] if trailing else raw
-    for indent in INDENT_CANDIDATES:
-        if json.dumps(parsed, indent=indent, ensure_ascii=False) == body:
-            return indent, trailing, True
-    return DEFAULT_INDENT, trailing, False
+    body = raw.rstrip()
+    trailing = raw[len(body):]
+
+    candidates = [(STYLE_INDENT, i) for i in INDENT_CANDIDATES]
+    candidates += [(STYLE_COMPACT, None), (STYLE_COMPACT_SPACED, None),
+                   (STYLE_EMPTY_NEWLINE, None)]
+    for style, indent in candidates:
+        if _render(parsed, style, indent) == body:
+            return {"style": style, "indent": indent, "trailing": trailing,
+                    "format_exact": True}
+    return {"style": STYLE_INDENT, "indent": DEFAULT_INDENT, "trailing": trailing,
+            "format_exact": False}
 
 
 def read_json_file(path):
-    """Return (parsed, format metadata). Files in this repo disagree about both
-    indent width and the trailing newline, so both are recorded."""
+    """Return (parsed, format metadata)."""
     with open(path, encoding="utf-8") as handle:
         raw = handle.read()
     parsed = json.loads(raw)
-    indent, trailing, exact = detect_format(raw, parsed)
-    return parsed, {"indent": indent, "trailing_newline": trailing, "format_exact": exact}
+    return parsed, detect_format(raw, parsed)
 
 
-def serialize(payload, indent, trailing_newline):
-    text = json.dumps(payload, indent=indent, ensure_ascii=False)
-    return text + "\n" if trailing_newline else text
+def serialize(payload, meta):
+    text = _render(payload, meta.get("style", STYLE_INDENT),
+                   meta.get("indent", DEFAULT_INDENT))
+    return text + meta.get("trailing", "")
 
 
 def content_hash(payload):
@@ -78,6 +105,21 @@ def _content_doc(entry, locale, acronym, kind):
     return doc
 
 
+def _lore_doc(entry, locale, lore_source):
+    doc = dict(entry)
+    doc["locale"] = locale
+    doc["lore_source"] = lore_source
+    doc["_id"] = "%s:%s:%s" % (locale, lore_source, entry["index"])
+    return doc
+
+
+def _image_doc(entry, catalog):
+    doc = dict(entry)
+    doc["catalog"] = catalog
+    doc["_id"] = "%s:%s" % (catalog, entry["monster_index"])
+    return doc
+
+
 def _source_doc(entry, locale, catalog):
     acronym = entry["source"]["acronym"]
     doc = {}
@@ -98,7 +140,8 @@ def files_to_documents():
     formatting needed to rebuild the files, and duplicates lists any
     (file, index) that appeared twice inside a single file.
     """
-    collections = {"monsters": [], "spells": [], "conditions": [], "sources": []}
+    collections = {"monsters": [], "spells": [], "conditions": [], "sources": [],
+                   "monster_lore": [], "monster_images": []}
     file_meta = []
     duplicates = []
 
@@ -131,6 +174,23 @@ def files_to_documents():
             for entry in load_entries(path):
                 collections["sources"].append(_source_doc(entry, locale, catalog))
 
+        for lore_source, path in mf.lore_files(locale):
+            seen = set()
+            for entry in load_entries(path):
+                if entry["index"] in seen:
+                    duplicates.append((mf.rel(path), entry["index"]))
+                seen.add(entry["index"])
+                collections["monster_lore"].append(
+                    _lore_doc(entry, locale, lore_source))
+
+    for catalog, path in mf.image_files():
+        seen = set()
+        for entry in load_entries(path):
+            if entry["monster_index"] in seen:
+                duplicates.append((mf.rel(path), entry["monster_index"]))
+            seen.add(entry["monster_index"])
+            collections["monster_images"].append(_image_doc(entry, catalog))
+
     _attach_translation_revisions(collections)
     return collections, file_meta, duplicates
 
@@ -145,16 +205,18 @@ def _attach_translation_revisions(collections):
     import every existing translation is stamped as current; that is a baseline
     to measure future drift against, not a claim that it is accurate today.
     """
-    for kind in ("monsters", "spells"):
+    scoped = {"monsters": "source_acronym", "spells": "source_acronym",
+              "monster_lore": "lore_source"}
+    for kind, scope_field in scoped.items():
         base = {}
         for doc in collections[kind]:
             if doc["locale"] == mf.BASE_LOCALE:
-                key = (doc["source_acronym"], doc["index"])
+                key = (doc[scope_field], doc["index"])
                 base[key] = content_hash(_strip_injected(doc))
         for doc in collections[kind]:
             if doc["locale"] == mf.BASE_LOCALE:
                 continue
-            key = (doc["source_acronym"], doc["index"])
+            key = (doc[scope_field], doc["index"])
             doc["translated_from_rev"] = base.get(key)
 
 
@@ -194,12 +256,21 @@ def documents_to_files(collections, file_meta):
                 if doc["locale"] == locale and doc["catalog"] == catalog:
                     add(path, _unsource_doc(doc))
 
-    out = {}
-    for path, entries in grouped.items():
-        meta = fmt.get(path, {})
-        out[path] = serialize(
-            entries,
-            meta.get("indent", DEFAULT_INDENT),
-            meta.get("trailing_newline", False),
-        )
-    return out
+        by_book = {}
+        for doc in collections.get("monster_lore", []):
+            if doc["locale"] == locale:
+                by_book.setdefault(doc["lore_source"], []).append(doc)
+        for lore_source, path in mf.lore_files(locale):
+            for doc in by_book.get(lore_source, []):
+                add(path, _strip_injected(doc))
+            grouped.setdefault(mf.rel(path), [])  # empty books still emit "[]"
+
+    for catalog, path in mf.image_files():
+        for doc in collections.get("monster_images", []):
+            if doc["catalog"] == catalog:
+                add(path, _strip_injected(doc))
+
+    return {
+        path: serialize(entries, fmt.get(path, {}))
+        for path, entries in grouped.items()
+    }

--- a/scripts/mongo/verify.py
+++ b/scripts/mongo/verify.py
@@ -90,9 +90,17 @@ def validate(value, schema, path=""):
 
 
 def check_roundtrip(collections_map, file_meta):
+    """Compare rebuilt files with the working tree.
+
+    A file whose formatting was detected as not reproducible is expected to
+    come back reformatted; that is reported separately rather than as a
+    failure, because the alternative is storing its raw bytes forever. Any
+    other difference is a real fidelity bug.
+    """
     rebuilt = transform.documents_to_files(collections_map, file_meta)
     read_paths = {m["_id"] for m in file_meta}
-    problems = []
+    inexact = {m["_id"] for m in file_meta if not m.get("format_exact", True)}
+    problems, expected = [], []
     for relpath in sorted(read_paths - set(rebuilt)):
         problems.append("%s: read but not rebuilt" % relpath)
     for relpath in sorted(set(rebuilt) - read_paths):
@@ -102,9 +110,11 @@ def check_roundtrip(collections_map, file_meta):
         with open(os.path.join(mf.REPO_ROOT, relpath), encoding="utf-8") as handle:
             if handle.read() == text:
                 identical += 1
+            elif relpath in inexact:
+                expected.append(relpath)
             else:
                 problems.append("%s: differs after round trip" % relpath)
-    return identical, len(rebuilt), problems
+    return identical, len(rebuilt), problems, expected
 
 
 def check_validators(collections_map):
@@ -125,8 +135,10 @@ def main():
     failed = False
 
     print("\n1. Round trip")
-    identical, total, problems = check_roundtrip(collections_map, file_meta)
+    identical, total, problems, expected = check_roundtrip(collections_map, file_meta)
     print("   %d / %d files byte-identical" % (identical, total))
+    for relpath in expected:
+        print("   normalised (formatting was not reproducible): %s" % relpath)
     for problem in problems[:20]:
         print("   FAIL %s" % problem)
     if problems:
@@ -134,7 +146,7 @@ def main():
 
     print("\n2. Validator fit")
     results = check_validators(collections_map)
-    for name in ("monsters", "spells", "conditions", "sources"):
+    for name in sorted(results):
         failures = results[name]
         total_docs = len(collections_map[name])
         if failures:


### PR DESCRIPTION
Second pass over the content tree, following #27. Adds `monster_lore` (5,965 docs) and `monster_images` (1,345), bringing the database to 13,759 documents across 6 collections.

## Two assumptions from #27 were wrong

- **`monster-images-srd.json` is not a subset of `monster-images.json`.** They share 322 `monster_index` values and **disagree on the `image_url` for 298 of them** — one points at `srd-v2/`, the other at `images/`. These are separate art sets, so each is imported under its own `catalog` (`default` / `srd`). Merging them, as the earlier plan assumed, would have silently dropped one.
- **Images are not folded into the monster documents.** They carry no `locale` and are keyed by `monster_index` alone, while monsters are keyed by `(locale, source_acronym, index)`. Folding would store each image 3× per locale and again per source, and could not represent two catalogs.

## Collections

| Collection | Docs | `_id` | Locale-scoped |
|---|---|---|---|
| `monster_lore` | 5,965 | `<locale>:<lore_source>:<index>` | yes |
| `monster_images` | 1,345 | `<catalog>:<monster_index>` | **no** |

Lore needs the book in its key for the same reason monsters need their source: **333 lore indexes appear in more than one book** (`azer` has lore in `mtf`, `mm2024` and `mm`).

Lore books are their own taxonomy — 40 mostly-adventure titles, only 8 of which are also content sources — and **698 lore indexes describe monsters with no stat block anywhere in the tree**, so lore cannot be modelled as a property of a monster.

## The bulk of the diff is format detection

Lore exposed four serialization cases the content files never did:

| Case | Files |
|---|---|
| Compact/minified output | the 2 legacy root lore aggregates |
| Trailing whitespace that isn't a single `\n` | `json/pt-br/lore/psb3/monster-lore.json` ends `]\n` + 16 spaces |
| Empty arrays written `[\n]`, not `[]` | 6 files: `llk`/`lr`/`tce` × `en-us`/`es` |
| Hand-edited indentation no serializer emits | `json/en-us/lore/erlw/monster-lore.json` |

`_file_meta` now records `{style, indent, trailing}` instead of `{indent, trailing_newline}`. **This invalidates existing `_file_meta` docs — reviewers testing locally need `import.py --drop`.**

`erlw` is the one file that cannot be reproduced (two array elements at 8 spaces instead of 4). It's recorded as `format_exact: false` and will be reindented on the first publish — a 2-line whitespace-only diff. `verify.py` and `export.py --check` now report it as a *known normalisation* rather than a failure, so the check doesn't sit permanently red for an accepted reason.

## Deliberately not imported

- `json/<locale>/monster-lore.json` — a stale January-2023 aggregate: a list of 38 lists whose group order matches no config, holding 1,476 of the directories' 1,988 entries, missing `erlw`/`mm2024`/`psb3`, byte-identical between `en-us` and `pt-br` (never translated), absent for `es`.
- `json/monster-lore-sources.json` — legacy, no longer read by the app. **Consequence worth a decision:** it was the only place mapping lore acronyms to book names, so the 32 lore books that aren't also content sources now have no display name anywhere in the repo. Authoring those is content work, not migration work — resurrecting a 2023 file would import names for books whose lore has since changed.

## Verification

- **Regression:** the 57 files from #27 still round-trip byte-exactly after the format-detection rewrite. This was the check that mattered most.
- **Round trip:** 175/176 byte-identical, `erlw` the single recorded exception. The unmanaged legacy files correctly never appear in export output.
- **Validators:** 9 invalid cases rejected server-side (entry missing `description`, empty `entries`, missing `background_color.dark`, bad `catalog`, bad `content_scale`, …); 6 valid accepted, including images with **no** `content_scale` (absent on 26 of 322 SRD entries) and lore entries with no `title`.
- **Collisions:** `azer` lore resolves to 3 books; `acolyte` images resolve to 2 catalogs with genuinely different URLs.
- **Idempotency:** second run 0 inserted, all replaced.

`verify.py` exits 0. No file under `json/` is modified by this PR.

## Baseline findings now 12 warnings, 4 infos, 0 errors

New this pass: 15 monsters with no image in either catalog, 49 image entries referencing indexes with no stat block, 698 orphan lore indexes, one `pt-br` lore entry (`dinosaurs` in `erlw`) with no `en-us` counterpart, and the `erlw` formatting note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
